### PR TITLE
Remove dublicate key 'inlucde' from snippet

### DIFF
--- a/snippets/PHP-twig.cson
+++ b/snippets/PHP-twig.cson
@@ -38,9 +38,6 @@
   'include':
     'prefix': 'inc'
     'body': '{% include \'${1:template}\' ${2:with ${3:vars}${4: only}} %}$0'
-  'include':
-    'prefix': 'include'
-    'body': '{% include \'${1:template}\' ${2:with ${3:vars}${4: only}} %}$0'
   'set (block)':
     'prefix': 'setb'
     'body': '{% set ${1:var} %}\n\t$0\n{% endset %}'


### PR DESCRIPTION
This is causing an error in Atom v1.23.1

![image](https://user-images.githubusercontent.com/10676525/34917126-72f55c70-f942-11e7-9750-a10d35c257d1.png)
